### PR TITLE
CSHARP-2405: ImmutableTypeClassMapConvention should not consider static properties

### DIFF
--- a/src/MongoDB.Bson/Serialization/Conventions/ImmutableTypeClassMapConvention.cs
+++ b/src/MongoDB.Bson/Serialization/Conventions/ImmutableTypeClassMapConvention.cs
@@ -39,7 +39,7 @@ namespace MongoDB.Bson.Serialization.Conventions
                 return;
             }
 
-            var properties = typeInfo.GetProperties();
+            var properties = typeInfo.GetProperties(BindingFlags.Instance | BindingFlags.Public);
             if (properties.Any(p => p.CanWrite))
             {
                 return; // a type that has any writable properties is not immutable


### PR DESCRIPTION
By default, i.e. calling `GetProperties()` without any parameters is the same as calling with `Instance, Public and Static`. This results in discovering 2 properties (static C and int X) but there's only 1 defined constructor parameter. Thus, in `src/MongoDB.Bson/Serialization/Conventions/ImmutableTypeClassMapConvention.cs` the number of constructor parameter does not match with the number of properties. Changing `GetProperties()` with only `Instance and Public` returns only 1 properties (int X), which fixes it. 

https://evergreen.mongodb.com/version/5d0c45dbd6d80a13a3759e15

