### PR TITLE
CSHARP-2405: ImmutableTypeClassMapConvention should not consider static properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Please see our [guidelines](CONTRIBUTING.md) for contributing to the driver.
 * Bar Arnon                 https://github.com/I3arnon
 * Wan Bachtiar              https://github.com/sindbach
 * Mark Benvenuto            https://github.com/markbenvenuto
+* Ross Buggins              https://github.com/rbugginsvia
 * Ethan Celletti            https://github.com/Gekctek
 * Bit Diffusion Limited     code@bitdiff.com
 * Nima Boscarino            https://github.com/NimaBoscarino

--- a/src/MongoDB.Bson/Serialization/Conventions/ImmutableTypeClassMapConvention.cs
+++ b/src/MongoDB.Bson/Serialization/Conventions/ImmutableTypeClassMapConvention.cs
@@ -39,7 +39,7 @@ namespace MongoDB.Bson.Serialization.Conventions
                 return;
             }
 
-            var properties = typeInfo.GetProperties();
+            var properties = typeInfo.GetProperties(BindingFlags.Instance | BindingFlags.Public );
             if (properties.Any(p => p.CanWrite))
             {
                 return; // a type that has any writable properties is not immutable

--- a/tests/MongoDB.Bson.Tests/Serialization/Conventions/ImmutableTypeClassMapConventionTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Conventions/ImmutableTypeClassMapConventionTests.cs
@@ -64,9 +64,18 @@ namespace MongoDB.Bson.Tests.Serialization.Conventions
         {
             public TestClassD(int a) { A = a; }
 
-            public static TestClassD Default {get; } = new TestClassD(0);
+            public static TestClassD Default => new TestClassD(0);
 
             public int A { get; }
+        }
+
+        private class TestClassE
+        {
+            public TestClassE(int a) { A = a; }
+
+            public static TestClassE Default => new TestClassE(0);
+
+            public int A { get; set; }
         }
 
         [Fact]
@@ -145,5 +154,14 @@ namespace MongoDB.Bson.Tests.Serialization.Conventions
             Assert.Equal(1, classMap.CreatorMaps.Count());
         }
 
+        [Fact]
+        public void TestNoDefaultConstructorClassMapConventionWithTestClassE()
+        {
+            var convention = new ImmutableTypeClassMapConvention();
+            var classMap = new BsonClassMap<TestClassE>();
+            convention.Apply(classMap);
+            Assert.False(classMap.HasCreatorMaps);
+            Assert.Equal(0, classMap.CreatorMaps.Count());
+        }
     }
 }

--- a/tests/MongoDB.Bson.Tests/Serialization/Conventions/ImmutableTypeClassMapConventionTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Conventions/ImmutableTypeClassMapConventionTests.cs
@@ -60,6 +60,15 @@ namespace MongoDB.Bson.Tests.Serialization.Conventions
             }
         }
 
+        private class TestClassD
+                {
+            public TestClassD(int a) { A = a; }
+
+            public static TestClassD Default {get; } = new TestClassD(0);
+
+            public int A { get; }
+        }
+
         [Fact]
         public void Anonymous_class_should_map_correctly()
         {
@@ -125,5 +134,16 @@ namespace MongoDB.Bson.Tests.Serialization.Conventions
             Assert.True(classMap.HasCreatorMaps);
             Assert.Equal(1, classMap.CreatorMaps.Count());
         }
+                
+        [Fact]
+        public void TestNoDefaultConstructorClassMapConventionWithTestClassD()
+        {
+            var convention = new ImmutableTypeClassMapConvention();
+            var classMap = new BsonClassMap<TestClassD>();
+            convention.Apply(classMap);
+            Assert.True(classMap.HasCreatorMaps);
+            Assert.Equal(1, classMap.CreatorMaps.Count());
+        }
+
     }
 }

--- a/tests/MongoDB.Bson.Tests/Serialization/Conventions/ImmutableTypeClassMapConventionTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Conventions/ImmutableTypeClassMapConventionTests.cs
@@ -78,6 +78,15 @@ namespace MongoDB.Bson.Tests.Serialization.Conventions
             public int A { get; set; }
         }
 
+        private class TestClassF
+        {
+            public TestClassF(int a) { A = a; }
+
+            public static TestClassF Default { get; set; } = new TestClassF(0);
+
+            public int A { get; }
+        }
+
         [Fact]
         public void Anonymous_class_should_map_correctly()
         {
@@ -162,6 +171,16 @@ namespace MongoDB.Bson.Tests.Serialization.Conventions
             convention.Apply(classMap);
             Assert.False(classMap.HasCreatorMaps);
             Assert.Equal(0, classMap.CreatorMaps.Count());
+        }
+
+        [Fact]
+        public void TestNoDefaultConstructorClassMapConventionWithTestClassF()
+        {
+            var convention = new ImmutableTypeClassMapConvention();
+            var classMap = new BsonClassMap<TestClassF>();
+            convention.Apply(classMap);
+            Assert.True(classMap.HasCreatorMaps);
+            Assert.Equal(1, classMap.CreatorMaps.Count());
         }
     }
 }

--- a/tests/MongoDB.Bson.Tests/Serialization/Conventions/ImmutableTypeClassMapConventionTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Conventions/ImmutableTypeClassMapConventionTests.cs
@@ -61,7 +61,7 @@ namespace MongoDB.Bson.Tests.Serialization.Conventions
         }
 
         private class TestClassD
-                {
+        {
             public TestClassD(int a) { A = a; }
 
             public static TestClassD Default {get; } = new TestClassD(0);


### PR DESCRIPTION
-Included Ross Buggins PR 
-Added Ross as a contributor in README
-Added test

Evergreen: https://evergreen.mongodb.com/version/5da518e0e3c33150766585aa